### PR TITLE
store FASTA header / seqID in Seq object

### DIFF
--- a/lib/nt.js
+++ b/lib/nt.js
@@ -1008,6 +1008,50 @@ var Nt = function() {
 
   };
 
+  /* SeqLibrary */
+
+  function SeqLibrary(type) {
+
+    if (type === undefined) {
+      type = 'DNA';
+    }
+
+    if (!{'RNA': true, 'DNA': true}[type]) {
+      throw new Error('Sequence type ' + type + ' not supported');
+    }
+
+    this.__type = type;
+    this.__collection = new Array();
+  };
+
+  SeqLibrary.prototype.readMultiFASTA = function(strFASTA) {
+    
+    var data = strFASTA.split(/\n\r?/gi);
+    var seqJoin = ''
+
+    for (const line of data) {
+      
+      if (line[0] === '>') {
+
+        if (seqJoin !== '') {
+          
+          seq.__buffer = seq.read(seqJoin).__buffer;
+          this.__collection.push(seq);
+          seqJoin = '';
+        }
+
+        var seq = new Seq(this.__type);
+        seq.__seqID = line;
+
+      } else {
+        seqJoin += line
+      }
+    }
+
+    seq.__buffer = seq.read(seqJoin).__buffer;
+    this.__collection.push(seq);
+  };
+
   /* MatchResult */
 
   function MatchResult(matchMap, pos, score) {
@@ -1017,7 +1061,6 @@ var Nt = function() {
     this.position = pos;
     this.score = score;
     this.__align = null;
-
   };
 
   MatchResult.prototype.alignment = function() {
@@ -1331,6 +1374,7 @@ var Nt = function() {
 
   return {
     Seq: Seq,
+    SeqLibrary, SeqLibrary,
     MatchMap: MatchMap
   };
 
@@ -1371,6 +1415,12 @@ void function nodeExtension(Nt) {
     fs.writeFileSync(path + '/' + name + '.4bnt', new Buffer(new Uint8Array(this.__buffer)));
 
     return true;
+
+  };
+
+  Nt.SeqLibrary.prototype.loadMultiFASTA = function(paths) {
+
+    paths.map(path => this.readMultiFASTA(fs.readFileSync(path).toString()));
 
   };
 

--- a/lib/nt.js
+++ b/lib/nt.js
@@ -265,6 +265,7 @@ var Nt = function() {
 
     this.__endPadding = 0;
 
+    this.__seqID = null
     this.__buffer = new ArrayBuffer(4);
 
     this.__complement = null;
@@ -332,6 +333,7 @@ var Nt = function() {
     var data = strFASTA.split(/\n\r?/gi);
 
     while (data.length && data[0][0] === '>') {
+      this.__seqID = data[0];
       data.shift();
     }
 


### PR DESCRIPTION
When loading single record FASTA files to a Seq object, FASTA header / sequence identifier is now stored in Nt.Seq.__seqID